### PR TITLE
Bug fix for shipment items

### DIFF
--- a/src/hooks/useApiSpec.ts
+++ b/src/hooks/useApiSpec.ts
@@ -46,7 +46,7 @@ const psuedoResources: IPsuedoResource[] = [
   },
   {
     name: 'Shipment Items',
-    paths: ['/shipments/{shipmentID}/items'],
+    paths: ['/shipments/{shipmentID}/items', '/shipments/{shipmentID}/items/{orderID}/{lineItemID}'],
     getOperationId: (resourceId, o) => {
       return resourceId + '.' + o?.operationId?.split('.')[1].split('Item')[0]
     },


### PR DESCRIPTION
- Add path to pseudoResources for shipment items to enable DELETE operation (`/shipments/{shipmentID}/items/{orderID}/{lineItemID}`)
- Ensure fallback operation for mutate hook
- Only remove the GET cache for specific parameters on item DELETE
- If no item ID (e.g. shipment item), invalidate list query instead of removing a specific ID from the list cache