### PR TITLE
Updates for shopper endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rwatt451/ordercloud-react",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rwatt451/ordercloud-react",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",
         "@react-native-async-storage/async-storage": "^1.21.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rwatt451/ordercloud-react",
   "private": false,
-  "version": "0.0.24",
+  "version": "0.0.25",
   "type": "module",
   "files": [
     "package.json",

--- a/src/context.ts
+++ b/src/context.ts
@@ -16,6 +16,7 @@ const INITIAL_ORDERCLOUD_CONTEXT: IOrderCloudContext = {
   customScope: [],
   allowAnonymous: false,
   token: undefined,
+  autoApplyPromotions: false,
   xpSchemas: {} as OpenAPIV3.SchemaObject
 };
 

--- a/src/formSchemaGenerator.utils.tsx
+++ b/src/formSchemaGenerator.utils.tsx
@@ -126,7 +126,7 @@ function typeSpecificTransform(type: string, propName: string) {
 function ShapeStringProp(propName: string, target: any) {
   let propShape
   propShape = yup.string()
-  if (propName.toLocaleLowerCase() === 'email') {
+  if (propName?.toLocaleLowerCase() === 'email') {
     propShape = propShape.email('Email is invalid')
   }
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,25 +1,35 @@
 import useOrderCloudContext from "./useOrderCloudContext";
 import useAuthQuery from "./useAuthQuery";
-import useAuthMutation from "./useAuthMutation"
+import useAuthMutation from "./useAuthMutation";
 import useColumns from "./useColumns";
-import { useOcResourceList, useOcResourceGet, useMutateOcResource, useDeleteOcResource, useListAssignments, useMutateAssignment, useDeleteAssignment } from "./useOcResource";
+import {
+  useOcResourceList,
+  useOcResourceListWithFacets,
+  useOcResourceGet,
+  useMutateOcResource,
+  useDeleteOcResource,
+  useListAssignments,
+  useMutateAssignment,
+  useDeleteAssignment,
+} from "./useOcResource";
 import { useOcForm } from "./useOcForm";
 import useHasAccess from "./useHasAccess";
 import { usePromoExpressions } from "./usePromoExpressions";
 
 export {
-    useAuthQuery,
-    useAuthMutation,
-    useOrderCloudContext,
-    useColumns,
-    useOcResourceList,
-    useOcResourceGet,
-    useMutateOcResource,
-    useDeleteOcResource,
-    useOcForm,
-    useListAssignments,
-    useMutateAssignment,
-    useDeleteAssignment,
-    useHasAccess,
-    usePromoExpressions
-}
+  useAuthQuery,
+  useAuthMutation,
+  useOrderCloudContext,
+  useColumns,
+  useOcResourceList,
+  useOcResourceListWithFacets,
+  useOcResourceGet,
+  useMutateOcResource,
+  useDeleteOcResource,
+  useOcForm,
+  useListAssignments,
+  useMutateAssignment,
+  useDeleteAssignment,
+  useHasAccess,
+  usePromoExpressions,
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -15,6 +15,7 @@ import {
 import { useOcForm } from "./useOcForm";
 import useHasAccess from "./useHasAccess";
 import { usePromoExpressions } from "./usePromoExpressions";
+import useShopper from "./useShopper";
 
 export {
   useAuthQuery,
@@ -32,4 +33,5 @@ export {
   useDeleteAssignment,
   useHasAccess,
   usePromoExpressions,
+  useShopper,
 };

--- a/src/hooks/useOcResource.ts
+++ b/src/hooks/useOcResource.ts
@@ -30,13 +30,14 @@ export function useOcResourceList<TData>(
   isMeEndpoint?: boolean
 ) {
   const { listOperation } = useOperations(resource, undefined, isMeEndpoint);
+  if(!listOperation) console.error(`List${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`);
+
   const queryString = makeQueryString(listOptions);
   const { baseApiUrl, token } = useOrderCloudContext();
 
-  const url = listOperation?.path
-    ? getRoutingUrl(listOperation, parameters) +
-      (queryString ? `?${queryString}` : "")
-    : "";
+  const url =
+    getRoutingUrl(listOperation, parameters) +
+    (queryString ? `?${queryString}` : "");
 
   const axiosRequest: AxiosRequestConfig = {
     method: listOperation ? listOperation?.verb.toLocaleLowerCase() : "",
@@ -50,6 +51,7 @@ export function useOcResourceList<TData>(
       const resp = await axios.get<TData>(url, axiosRequest);
       return resp.data;
     },
+    disabled: queryOptions?.disabled || !url,
     ...queryOptions,
   }) as UseQueryResult<RequiredDeep<ListPage<TData>>, OrderCloudError>;
 }
@@ -62,13 +64,13 @@ export function useOcResourceListWithFacets<TData>(
   isMeEndpoint?: boolean
 ) {
   const { listOperation } = useOperations(resource, undefined, isMeEndpoint);
+  if(!listOperation) console.error(`List${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`);
   const queryString = makeQueryString(listOptions);
   const { baseApiUrl, token } = useOrderCloudContext();
 
-  const url = listOperation?.path
-    ? getRoutingUrl(listOperation, parameters) +
-      (queryString ? `?${queryString}` : "")
-    : "";
+  const url =
+    getRoutingUrl(listOperation, parameters) +
+    (queryString ? `?${queryString}` : "");
 
   const axiosRequest: AxiosRequestConfig = {
     method: listOperation ? listOperation?.verb.toLocaleLowerCase() : "",
@@ -82,8 +84,12 @@ export function useOcResourceListWithFacets<TData>(
       const resp = await axios.get<TData>(url, axiosRequest);
       return resp.data;
     },
+    disabled: queryOptions?.disabled || !url,
     ...queryOptions,
-  }) as UseQueryResult<RequiredDeep<ListPageWithFacets<TData>>, OrderCloudError>;
+  }) as UseQueryResult<
+    RequiredDeep<ListPageWithFacets<TData>>,
+    OrderCloudError
+  >;
 }
 
 export function useOcResourceGet<TData>(
@@ -93,8 +99,9 @@ export function useOcResourceGet<TData>(
   isMeEndpoint?: boolean
 ) {
   const { getOperation } = useOperations(resource, undefined, isMeEndpoint);
+  if(!getOperation) console.error(`Get${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`);
   const { baseApiUrl, token } = useOrderCloudContext();
-  const url = getOperation?.path ? getRoutingUrl(getOperation, parameters) : "";
+  const url = getRoutingUrl(getOperation, parameters);
 
   const axiosRequest: AxiosRequestConfig = {
     method: getOperation ? getOperation?.verb.toLocaleLowerCase() : "",
@@ -108,6 +115,7 @@ export function useOcResourceGet<TData>(
       const resp = await axios.get<TData>(url, axiosRequest);
       return resp.data;
     },
+    disabled: queryOptions?.disabled || !url,
     ...queryOptions,
   }) as UseQueryResult<RequiredDeep<TData>, OrderCloudError>;
 }
@@ -123,7 +131,9 @@ export function useMutateOcResource<TData>(
     useOperations(resource, undefined, isMeEndpoint);
   const { baseApiUrl, token } = useOrderCloudContext();
   const operation = isNew && createOperation ? createOperation : saveOperation;
-  const url = operation?.path ? getRoutingUrl(operation, parameters) : "";
+  if(!operation) console.error(`${isNew ? 'Create' : 'Save'} ${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`); 
+
+  const url = getRoutingUrl(operation, parameters);
   const axiosRequest: AxiosRequestConfig = {
     method: operation ? operation?.verb.toLocaleLowerCase() : "",
     baseURL: baseApiUrl + "/v1",
@@ -160,6 +170,7 @@ export function useMutateOcResource<TData>(
           }
         );
     },
+    disabled: mutationOptions?.disabled || !url,
     ...mutationOptions,
   }) as UseMutationResult<RequiredDeep<TData>, OrderCloudError>;
 }
@@ -170,12 +181,17 @@ export function useDeleteOcResource<TData>(
   mutationOptions?: Omit<UseOcMutationOptions<TData>, "mutationKey">,
   isMeEndpoint?: boolean
 ) {
-  const { deleteOperation, listOperation, getOperation } =
-    useOperations(resource, undefined, isMeEndpoint);
+  const { deleteOperation, listOperation, getOperation } = useOperations(
+    resource,
+    undefined,
+    isMeEndpoint
+  );
+  if(!deleteOperation) console.error(`Delete${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`);
+
   const { columnHeaders } = useColumns(resource);
   const { baseApiUrl, token } = useOrderCloudContext();
 
-  const url = getRoutingUrl(deleteOperation, parameters)
+  const url = getRoutingUrl(deleteOperation, parameters);
 
   const axiosRequest: AxiosRequestConfig = {
     method: deleteOperation?.verb.toLocaleLowerCase() || "",
@@ -217,6 +233,7 @@ export function useDeleteOcResource<TData>(
         });
       }
     },
+    disabled: mutationOptions?.disabled || !url,
     ...mutationOptions,
   }) as UseMutationResult<void, OrderCloudError>;
 }
@@ -232,13 +249,14 @@ export function useListAssignments<TData>(
     resource,
     operationInclusion
   );
+  if(!assignmentListOperation) console.error(`List ${resource} Assignments is not a valid OrderCloud operation.`);
+
   const queryString = makeQueryString(listOptions);
   const { baseApiUrl, token } = useOrderCloudContext();
-  const url = assignmentListOperation?.path
-    ? getRoutingUrl(assignmentListOperation, parameters) +
-      (queryString ? `?${queryString}` : "")
-    : "";
-    
+  const url =
+    getRoutingUrl(assignmentListOperation, parameters) +
+    (queryString ? `?${queryString}` : "");
+
   const axiosRequest: AxiosRequestConfig = {
     method: assignmentListOperation
       ? assignmentListOperation?.verb.toLocaleLowerCase()
@@ -253,6 +271,7 @@ export function useListAssignments<TData>(
       const resp = await axios.get<TData>(url, axiosRequest);
       return resp.data;
     },
+    disabled: queryOptions?.disabled || !url,
     ...queryOptions,
   }) as UseQueryResult<RequiredDeep<ListPage<TData>>, OrderCloudError>;
 }
@@ -267,11 +286,10 @@ export function useMutateAssignment<TData>(
     resource,
     operationInclusion
   );
+  if(!assignmentSaveOperation) console.error(`Save ${resource} Assignments is not a valid OrderCloud operation.`);
 
   const { baseApiUrl, token } = useOrderCloudContext();
-  const url = assignmentSaveOperation?.path
-    ? getRoutingUrl(assignmentSaveOperation, parameters)
-    : "";
+  const url = getRoutingUrl(assignmentSaveOperation, parameters);
   const axiosRequest: AxiosRequestConfig = {
     method: assignmentSaveOperation
       ? assignmentSaveOperation?.verb.toLocaleLowerCase()
@@ -292,6 +310,7 @@ export function useMutateAssignment<TData>(
         queryKey: [assignmentListOperation?.operationId],
       });
     },
+    disabled: mutationOptions?.disabled || !url,
     ...mutationOptions,
   }) as UseMutationResult<void, OrderCloudError>;
 }
@@ -306,6 +325,7 @@ export function useDeleteAssignment<TData = unknown>(
     resource,
     operationInclusion
   );
+  if(!assignmentDeleteOperation) console.error(`Delete ${resource} Assignments is not a valid OrderCloud operation.`);
   const { baseApiUrl, token } = useOrderCloudContext();
   let queryString;
   if (parameters) {
@@ -317,10 +337,9 @@ export function useDeleteAssignment<TData = unknown>(
     });
     queryString = makeQueryString(queryParams);
   }
-  const url = assignmentDeleteOperation?.path
-    ? getRoutingUrl(assignmentDeleteOperation, parameters) +
-      (queryString ? `?${queryString}` : "")
-    : "";
+  const url =
+    getRoutingUrl(assignmentDeleteOperation, parameters) +
+    (queryString ? `?${queryString}` : "");
 
   const axiosRequest: AxiosRequestConfig = {
     method: assignmentDeleteOperation
@@ -342,6 +361,7 @@ export function useDeleteAssignment<TData = unknown>(
         queryKey: [assignmentListOperation?.operationId],
       });
     },
+    disabled: mutationOptions?.disabled || !url,
     ...mutationOptions,
   }) as UseMutationResult<void, OrderCloudError>;
 }

--- a/src/hooks/useOcResource.ts
+++ b/src/hooks/useOcResource.ts
@@ -22,15 +22,18 @@ export type ServiceListOptions = {
   [key: string]: ServiceListOptions | string | undefined;
 };
 
+function throwOperationNotFoundError(crudAction: string, resource: string){
+  console.error(`Could not find a valid OrderCloud ${crudAction} operation for resource: ${resource}`)
+}
+
 export function useOcResourceList<TData>(
   resource: string,
   listOptions?: ServiceListOptions,
   parameters?: { [key: string]: string },
-  queryOptions?: Omit<UseOcQueryOptions, "queryKey">,
-  isMeEndpoint?: boolean
+  queryOptions?: Omit<UseOcQueryOptions, "queryKey">
 ) {
-  const { listOperation } = useOperations(resource, undefined, isMeEndpoint);
-  if(!listOperation) console.error(`List${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`);
+  const { listOperation } = useOperations(resource);
+  if(!listOperation) throwOperationNotFoundError("List", resource)
 
   const queryString = makeQueryString(listOptions);
   const { baseApiUrl, token } = useOrderCloudContext();
@@ -51,7 +54,7 @@ export function useOcResourceList<TData>(
       const resp = await axios.get<TData>(url, axiosRequest);
       return resp.data;
     },
-    disabled: queryOptions?.disabled || !url,
+    disabled: queryOptions?.disabled || !listOperation,
     ...queryOptions,
   }) as UseQueryResult<RequiredDeep<ListPage<TData>>, OrderCloudError>;
 }
@@ -60,11 +63,10 @@ export function useOcResourceListWithFacets<TData>(
   resource: string,
   listOptions?: ServiceListOptions,
   parameters?: { [key: string]: string },
-  queryOptions?: Omit<UseOcQueryOptions, "queryKey">,
-  isMeEndpoint?: boolean
+  queryOptions?: Omit<UseOcQueryOptions, "queryKey">
 ) {
-  const { listOperation } = useOperations(resource, undefined, isMeEndpoint);
-  if(!listOperation) console.error(`List${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`);
+  const { listOperation } = useOperations(resource);
+  if(!listOperation) throwOperationNotFoundError("List", resource)
   const queryString = makeQueryString(listOptions);
   const { baseApiUrl, token } = useOrderCloudContext();
 
@@ -84,7 +86,7 @@ export function useOcResourceListWithFacets<TData>(
       const resp = await axios.get<TData>(url, axiosRequest);
       return resp.data;
     },
-    disabled: queryOptions?.disabled || !url,
+    disabled: queryOptions?.disabled || !listOperation,
     ...queryOptions,
   }) as UseQueryResult<
     RequiredDeep<ListPageWithFacets<TData>>,
@@ -95,11 +97,10 @@ export function useOcResourceListWithFacets<TData>(
 export function useOcResourceGet<TData>(
   resource: string,
   parameters?: { [key: string]: string },
-  queryOptions?: Omit<UseOcQueryOptions, "queryKey">,
-  isMeEndpoint?: boolean
+  queryOptions?: Omit<UseOcQueryOptions, "queryKey">
 ) {
-  const { getOperation } = useOperations(resource, undefined, isMeEndpoint);
-  if(!getOperation) console.error(`Get${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`);
+  const { getOperation } = useOperations(resource);
+  if(!getOperation) throwOperationNotFoundError("Get", resource)
   const { baseApiUrl, token } = useOrderCloudContext();
   const url = getRoutingUrl(getOperation, parameters);
 
@@ -115,7 +116,7 @@ export function useOcResourceGet<TData>(
       const resp = await axios.get<TData>(url, axiosRequest);
       return resp.data;
     },
-    disabled: queryOptions?.disabled || !url,
+    disabled: queryOptions?.disabled || !getOperation,
     ...queryOptions,
   }) as UseQueryResult<RequiredDeep<TData>, OrderCloudError>;
 }
@@ -124,14 +125,13 @@ export function useMutateOcResource<TData>(
   resource: string,
   parameters?: { [key: string]: string },
   mutationOptions?: Omit<UseOcMutationOptions<TData>, "mutationKey">,
-  isNew?: boolean,
-  isMeEndpoint?: boolean
+  isNew?: boolean
 ) {
   const { createOperation, saveOperation, getOperation, listOperation } =
-    useOperations(resource, undefined, isMeEndpoint);
+    useOperations(resource);
   const { baseApiUrl, token } = useOrderCloudContext();
   const operation = isNew && createOperation ? createOperation : saveOperation;
-  if(!operation) console.error(`${isNew ? 'Create' : 'Save'} ${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`); 
+  if(!operation) throwOperationNotFoundError(isNew ? 'Create' : 'Save', resource)
 
   const url = getRoutingUrl(operation, parameters);
   const axiosRequest: AxiosRequestConfig = {
@@ -170,7 +170,7 @@ export function useMutateOcResource<TData>(
           }
         );
     },
-    disabled: mutationOptions?.disabled || !url,
+    disabled: mutationOptions?.disabled || !operation,
     ...mutationOptions,
   }) as UseMutationResult<RequiredDeep<TData>, OrderCloudError>;
 }
@@ -178,15 +178,12 @@ export function useMutateOcResource<TData>(
 export function useDeleteOcResource<TData>(
   resource: string,
   parameters?: { [key: string]: string },
-  mutationOptions?: Omit<UseOcMutationOptions<TData>, "mutationKey">,
-  isMeEndpoint?: boolean
+  mutationOptions?: Omit<UseOcMutationOptions<TData>, "mutationKey">
 ) {
   const { deleteOperation, listOperation, getOperation } = useOperations(
-    resource,
-    undefined,
-    isMeEndpoint
+    resource
   );
-  if(!deleteOperation) console.error(`Delete${isMeEndpoint ? 'Me': ''} ${resource} is not a valid OrderCloud operation.`);
+  if(!deleteOperation) throwOperationNotFoundError("Delete", resource)
 
   const { columnHeaders } = useColumns(resource);
   const { baseApiUrl, token } = useOrderCloudContext();
@@ -233,7 +230,7 @@ export function useDeleteOcResource<TData>(
         });
       }
     },
-    disabled: mutationOptions?.disabled || !url,
+    disabled: mutationOptions?.disabled || !deleteOperation,
     ...mutationOptions,
   }) as UseMutationResult<void, OrderCloudError>;
 }
@@ -249,7 +246,7 @@ export function useListAssignments<TData>(
     resource,
     operationInclusion
   );
-  if(!assignmentListOperation) console.error(`List ${resource} Assignments is not a valid OrderCloud operation.`);
+  if(!assignmentListOperation) throwOperationNotFoundError("List Assignment", resource)
 
   const queryString = makeQueryString(listOptions);
   const { baseApiUrl, token } = useOrderCloudContext();
@@ -271,7 +268,7 @@ export function useListAssignments<TData>(
       const resp = await axios.get<TData>(url, axiosRequest);
       return resp.data;
     },
-    disabled: queryOptions?.disabled || !url,
+    disabled: queryOptions?.disabled || !assignmentListOperation,
     ...queryOptions,
   }) as UseQueryResult<RequiredDeep<ListPage<TData>>, OrderCloudError>;
 }
@@ -286,7 +283,7 @@ export function useMutateAssignment<TData>(
     resource,
     operationInclusion
   );
-  if(!assignmentSaveOperation) console.error(`Save ${resource} Assignments is not a valid OrderCloud operation.`);
+  if(!assignmentSaveOperation) throwOperationNotFoundError("Save Assignment", resource)
 
   const { baseApiUrl, token } = useOrderCloudContext();
   const url = getRoutingUrl(assignmentSaveOperation, parameters);
@@ -310,7 +307,7 @@ export function useMutateAssignment<TData>(
         queryKey: [assignmentListOperation?.operationId],
       });
     },
-    disabled: mutationOptions?.disabled || !url,
+    disabled: mutationOptions?.disabled || !assignmentSaveOperation,
     ...mutationOptions,
   }) as UseMutationResult<void, OrderCloudError>;
 }
@@ -325,7 +322,7 @@ export function useDeleteAssignment<TData = unknown>(
     resource,
     operationInclusion
   );
-  if(!assignmentDeleteOperation) console.error(`Delete ${resource} Assignments is not a valid OrderCloud operation.`);
+  if(!assignmentDeleteOperation) throwOperationNotFoundError("Delete Assignment", resource)
   const { baseApiUrl, token } = useOrderCloudContext();
   let queryString;
   if (parameters) {
@@ -361,7 +358,7 @@ export function useDeleteAssignment<TData = unknown>(
         queryKey: [assignmentListOperation?.operationId],
       });
     },
-    disabled: mutationOptions?.disabled || !url,
+    disabled: mutationOptions?.disabled || !assignmentDeleteOperation,
     ...mutationOptions,
   }) as UseMutationResult<void, OrderCloudError>;
 }

--- a/src/hooks/useOcResource.ts
+++ b/src/hooks/useOcResource.ts
@@ -26,9 +26,10 @@ export function useOcResourceList<TData>(
   resource: string,
   listOptions?: ServiceListOptions,
   parameters?: { [key: string]: string },
-  queryOptions?: Omit<UseOcQueryOptions, "queryKey">
+  queryOptions?: Omit<UseOcQueryOptions, "queryKey">,
+  isMeEndpoint?: boolean
 ) {
-  const { listOperation } = useOperations(resource);
+  const { listOperation } = useOperations(resource, undefined, isMeEndpoint);
   const queryString = makeQueryString(listOptions);
   const { baseApiUrl, token } = useOrderCloudContext();
 
@@ -38,7 +39,7 @@ export function useOcResourceList<TData>(
     : "";
 
   const axiosRequest: AxiosRequestConfig = {
-    method: listOperation ? listOperation.verb.toLocaleLowerCase() : "",
+    method: listOperation ? listOperation?.verb.toLocaleLowerCase() : "",
     baseURL: baseApiUrl + "/v1",
     headers: { Authorization: `Bearer ${token}` },
   };
@@ -57,9 +58,10 @@ export function useOcResourceListWithFacets<TData>(
   resource: string,
   listOptions?: ServiceListOptions,
   parameters?: { [key: string]: string },
-  queryOptions?: Omit<UseOcQueryOptions, "queryKey">
+  queryOptions?: Omit<UseOcQueryOptions, "queryKey">,
+  isMeEndpoint?: boolean
 ) {
-  const { listOperation } = useOperations(resource);
+  const { listOperation } = useOperations(resource, undefined, isMeEndpoint);
   const queryString = makeQueryString(listOptions);
   const { baseApiUrl, token } = useOrderCloudContext();
 
@@ -69,7 +71,7 @@ export function useOcResourceListWithFacets<TData>(
     : "";
 
   const axiosRequest: AxiosRequestConfig = {
-    method: listOperation ? listOperation.verb.toLocaleLowerCase() : "",
+    method: listOperation ? listOperation?.verb.toLocaleLowerCase() : "",
     baseURL: baseApiUrl + "/v1",
     headers: { Authorization: `Bearer ${token}` },
   };
@@ -87,14 +89,15 @@ export function useOcResourceListWithFacets<TData>(
 export function useOcResourceGet<TData>(
   resource: string,
   parameters?: { [key: string]: string },
-  queryOptions?: Omit<UseOcQueryOptions, "queryKey">
+  queryOptions?: Omit<UseOcQueryOptions, "queryKey">,
+  isMeEndpoint?: boolean
 ) {
-  const { getOperation } = useOperations(resource);
+  const { getOperation } = useOperations(resource, undefined, isMeEndpoint);
   const { baseApiUrl, token } = useOrderCloudContext();
   const url = getOperation?.path ? getRoutingUrl(getOperation, parameters) : "";
 
   const axiosRequest: AxiosRequestConfig = {
-    method: getOperation ? getOperation.verb.toLocaleLowerCase() : "",
+    method: getOperation ? getOperation?.verb.toLocaleLowerCase() : "",
     baseURL: baseApiUrl + "/v1",
     headers: { Authorization: `Bearer ${token}` },
   };
@@ -113,15 +116,16 @@ export function useMutateOcResource<TData>(
   resource: string,
   parameters?: { [key: string]: string },
   mutationOptions?: Omit<UseOcMutationOptions<TData>, "mutationKey">,
-  isNew?: boolean
+  isNew?: boolean,
+  isMeEndpoint?: boolean
 ) {
   const { createOperation, saveOperation, getOperation, listOperation } =
-    useOperations(resource);
+    useOperations(resource, undefined, isMeEndpoint);
   const { baseApiUrl, token } = useOrderCloudContext();
   const operation = isNew && createOperation ? createOperation : saveOperation;
   const url = operation?.path ? getRoutingUrl(operation, parameters) : "";
   const axiosRequest: AxiosRequestConfig = {
-    method: operation ? operation.verb.toLocaleLowerCase() : "",
+    method: operation ? operation?.verb.toLocaleLowerCase() : "",
     baseURL: baseApiUrl + "/v1",
     headers: { Authorization: `Bearer ${token}` },
   };
@@ -163,18 +167,18 @@ export function useMutateOcResource<TData>(
 export function useDeleteOcResource<TData>(
   resource: string,
   parameters?: { [key: string]: string },
-  mutationOptions?: Omit<UseOcMutationOptions<TData>, "mutationKey">
+  mutationOptions?: Omit<UseOcMutationOptions<TData>, "mutationKey">,
+  isMeEndpoint?: boolean
 ) {
   const { deleteOperation, listOperation, getOperation } =
-    useOperations(resource);
+    useOperations(resource, undefined, isMeEndpoint);
   const { columnHeaders } = useColumns(resource);
   const { baseApiUrl, token } = useOrderCloudContext();
-  const url = deleteOperation?.path
-    ? getRoutingUrl(deleteOperation, parameters)
-    : "";
+
+  const url = getRoutingUrl(deleteOperation, parameters)
 
   const axiosRequest: AxiosRequestConfig = {
-    method: deleteOperation ? deleteOperation.verb.toLocaleLowerCase() : "",
+    method: deleteOperation?.verb.toLocaleLowerCase() || "",
     baseURL: baseApiUrl + "/v1",
     headers: { Authorization: `Bearer ${token}` },
   };
@@ -237,7 +241,7 @@ export function useListAssignments<TData>(
     
   const axiosRequest: AxiosRequestConfig = {
     method: assignmentListOperation
-      ? assignmentListOperation.verb.toLocaleLowerCase()
+      ? assignmentListOperation?.verb.toLocaleLowerCase()
       : "",
     baseURL: baseApiUrl + "/v1",
     headers: { Authorization: `Bearer ${token}` },
@@ -270,7 +274,7 @@ export function useMutateAssignment<TData>(
     : "";
   const axiosRequest: AxiosRequestConfig = {
     method: assignmentSaveOperation
-      ? assignmentSaveOperation.verb.toLocaleLowerCase()
+      ? assignmentSaveOperation?.verb.toLocaleLowerCase()
       : "",
     baseURL: baseApiUrl + "/v1",
     headers: { Authorization: `Bearer ${token}` },
@@ -320,7 +324,7 @@ export function useDeleteAssignment<TData = unknown>(
 
   const axiosRequest: AxiosRequestConfig = {
     method: assignmentDeleteOperation
-      ? assignmentDeleteOperation.verb.toLocaleLowerCase()
+      ? assignmentDeleteOperation?.verb.toLocaleLowerCase()
       : "",
     baseURL: baseApiUrl + "/v1",
     headers: { Authorization: `Bearer ${token}` },

--- a/src/hooks/useOperations.ts
+++ b/src/hooks/useOperations.ts
@@ -1,89 +1,100 @@
-import { useCallback, useMemo } from 'react'
-import useApiSpec from './useApiSpec';
-import Case from 'case';
-import { IOrderCloudOperationObject } from '../models';
+import { useCallback, useMemo } from "react";
+import useApiSpec from "./useApiSpec";
+import Case from "case";
 
-const defaultReturn = { path: "", verb: "", operationId: ""} as IOrderCloudOperationObject
+const useOperations = (
+  resource: string,
+  operationInclusion?: string,
+  meEndpoint?: boolean
+) => {
+  const { operationsById } = useApiSpec();
+  const resourceName = useMemo(
+    () => resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1)),
+    [resource]
+  );
 
-const useOperations = (resource: string, operationInclusion?: string, meEndpoint?: boolean) => {
-  const { operationsById } = useApiSpec()
-  const resourceName = useMemo(()=> resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1)),[resource])
+  const tryGetOperation = useCallback(
+    (operationId: string) => operationsById[operationId],
+    [operationsById]
+  );
 
-  const tryGetOperation = useCallback((operationId: string)=> {
-    return operationsById[operationId] || defaultReturn
-  },[operationsById])
-  
   const listOperation = useMemo(() => {
-    let listOperationId
-    if(meEndpoint){
-      listOperationId = `Me.List${resourceName}`
+    let listOperationId;
+    if (meEndpoint) {
+      listOperationId = `Me.List${resourceName}`;
     } else {
-      listOperationId = `${resourceName}.List`
+      listOperationId = `${resourceName}.List`;
     }
 
-    return tryGetOperation(listOperationId)
-  }, [meEndpoint, resourceName, tryGetOperation])
+    return tryGetOperation(listOperationId);
+  }, [meEndpoint, resourceName, tryGetOperation]);
 
   const getOperation = useMemo(() => {
-    let getOperationId
-    if(meEndpoint){
-      getOperationId = `Me.Get${resource.slice(0, -1)}`
+    let getOperationId;
+    if (meEndpoint) {
+      getOperationId = `Me.Get${resource.slice(0, -1)}`;
     } else {
-      getOperationId = `${resourceName}.Get`
+      getOperationId = `${resourceName}.Get`;
     }
 
-    return tryGetOperation(getOperationId)
-  }, [meEndpoint, resource, resourceName, tryGetOperation])
+    return tryGetOperation(getOperationId);
+  }, [meEndpoint, resource, resourceName, tryGetOperation]);
 
   const saveOperation = useMemo(() => {
-    let saveOperationId
-    if(meEndpoint){
-      saveOperationId = `Me.Save${resource.slice(0, -1)}`
+    let saveOperationId;
+    if (meEndpoint) {
+      saveOperationId = `Me.Save${resource.slice(0, -1)}`;
     } else {
-      saveOperationId = `${resourceName}.Save`
+      saveOperationId = `${resourceName}.Save`;
     }
 
-    return tryGetOperation(saveOperationId)
-  }, [meEndpoint, resource, resourceName, tryGetOperation])
+    return tryGetOperation(saveOperationId);
+  }, [meEndpoint, resource, resourceName, tryGetOperation]);
 
   const createOperation = useMemo(() => {
-    let createOperationId
-    if(meEndpoint){
-      createOperationId = `Me.Create${resource.slice(0, -1)}`
+    let createOperationId;
+    if (meEndpoint) {
+      createOperationId = `Me.Create${resource.slice(0, -1)}`;
     } else {
-      createOperationId = `${resourceName}.Create`
+      createOperationId = `${resourceName}.Create`;
     }
-    
-    return tryGetOperation(createOperationId)
-  }, [meEndpoint, resource, resourceName, tryGetOperation])
+
+    return tryGetOperation(createOperationId);
+  }, [meEndpoint, resource, resourceName, tryGetOperation]);
 
   const deleteOperation = useMemo(() => {
-    let deleteOperationId
-    if(meEndpoint){
-      deleteOperationId = `Me.Delete${resource.slice(0, -1)}`
+    let deleteOperationId;
+    if (meEndpoint) {
+      deleteOperationId = `Me.Delete${resource.slice(0, -1)}`;
     } else {
-      deleteOperationId = `${resourceName}.Delete`
+      deleteOperationId = `${resourceName}.Delete`;
     }
 
-    return tryGetOperation(deleteOperationId)
-  }, [meEndpoint, resource, resourceName, tryGetOperation])
+    return tryGetOperation(deleteOperationId);
+  }, [meEndpoint, resource, resourceName, tryGetOperation]);
 
   const assignmentListOperation = useMemo(() => {
-    const assignmentListOperationId = `${resourceName}.List${operationInclusion ?? "" }Assignments`
-    return tryGetOperation(assignmentListOperationId)
-  }, [operationInclusion, resourceName, tryGetOperation])
+    const assignmentListOperationId = `${resourceName}.List${
+      operationInclusion ?? ""
+    }Assignments`;
+    return tryGetOperation(assignmentListOperationId);
+  }, [operationInclusion, resourceName, tryGetOperation]);
 
   const assignmentSaveOperation = useMemo(() => {
-    const assignmentSaveOperationId = `${resourceName}.Save${operationInclusion ?? "" }Assignment`
-    return tryGetOperation(assignmentSaveOperationId)
-  }, [operationInclusion, resourceName, tryGetOperation])
+    const assignmentSaveOperationId = `${resourceName}.Save${
+      operationInclusion ?? ""
+    }Assignment`;
+    return tryGetOperation(assignmentSaveOperationId);
+  }, [operationInclusion, resourceName, tryGetOperation]);
 
   const assignmentDeleteOperation = useMemo(() => {
-    const assignmentDeleteOperationId = `${resourceName}.Delete${operationInclusion ?? "" }Assignment`
-    return tryGetOperation(assignmentDeleteOperationId)
-  }, [operationInclusion, resourceName, tryGetOperation])
+    const assignmentDeleteOperationId = `${resourceName}.Delete${
+      operationInclusion ?? ""
+    }Assignment`;
+    return tryGetOperation(assignmentDeleteOperationId);
+  }, [operationInclusion, resourceName, tryGetOperation]);
 
-  const result = useMemo(() => {    
+  const result = useMemo(() => {
     return {
       listOperation,
       getOperation,
@@ -92,11 +103,20 @@ const useOperations = (resource: string, operationInclusion?: string, meEndpoint
       createOperation,
       assignmentListOperation,
       assignmentSaveOperation,
-      assignmentDeleteOperation
-    }
-  }, [listOperation, getOperation, saveOperation, deleteOperation, createOperation, assignmentListOperation, assignmentSaveOperation, assignmentDeleteOperation])
+      assignmentDeleteOperation,
+    };
+  }, [
+    listOperation,
+    getOperation,
+    saveOperation,
+    deleteOperation,
+    createOperation,
+    assignmentListOperation,
+    assignmentSaveOperation,
+    assignmentDeleteOperation,
+  ]);
 
-  return result
-}
+  return result;
+};
 
-export default useOperations
+export default useOperations;

--- a/src/hooks/useOperations.ts
+++ b/src/hooks/useOperations.ts
@@ -4,13 +4,16 @@ import Case from "case";
 
 const useOperations = (
   resource: string,
-  operationInclusion?: string,
-  meEndpoint?: boolean
+  operationInclusion?: string
 ) => {
   const { operationsById } = useApiSpec();
+  const isMeEndpoint = useMemo(()=> resource.includes('Me.'),[resource])
   const resourceName = useMemo(
-    () => resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1)),
-    [resource]
+    () => {
+      const resourceName = isMeEndpoint ? resource.replace("Me.", "") : resource
+      return resourceName.charAt(0).toUpperCase() + Case.camel(resourceName.slice(1))
+    },
+    [isMeEndpoint, resource]
   );
 
   const tryGetOperation = useCallback(
@@ -20,58 +23,57 @@ const useOperations = (
 
   const listOperation = useMemo(() => {
     let listOperationId;
-    if (meEndpoint) {
+    if (isMeEndpoint) {
       listOperationId = `Me.List${resourceName}`;
     } else {
       listOperationId = `${resourceName}.List`;
     }
-
     return tryGetOperation(listOperationId);
-  }, [meEndpoint, resourceName, tryGetOperation]);
+  }, [isMeEndpoint, resourceName, tryGetOperation]);
 
   const getOperation = useMemo(() => {
     let getOperationId;
-    if (meEndpoint) {
-      getOperationId = `Me.Get${resource.slice(0, -1)}`;
+    if (isMeEndpoint) {
+      getOperationId = `Me.Get${resourceName.slice(0, -1)}`;
     } else {
       getOperationId = `${resourceName}.Get`;
     }
 
     return tryGetOperation(getOperationId);
-  }, [meEndpoint, resource, resourceName, tryGetOperation]);
+  }, [isMeEndpoint, resourceName, tryGetOperation]);
 
   const saveOperation = useMemo(() => {
     let saveOperationId;
-    if (meEndpoint) {
-      saveOperationId = `Me.Save${resource.slice(0, -1)}`;
+    if (isMeEndpoint) {
+      saveOperationId = `Me.Save${resourceName.slice(0, -1)}`;
     } else {
       saveOperationId = `${resourceName}.Save`;
     }
 
     return tryGetOperation(saveOperationId);
-  }, [meEndpoint, resource, resourceName, tryGetOperation]);
+  }, [isMeEndpoint, resourceName, tryGetOperation]);
 
   const createOperation = useMemo(() => {
     let createOperationId;
-    if (meEndpoint) {
-      createOperationId = `Me.Create${resource.slice(0, -1)}`;
+    if (isMeEndpoint) {
+      createOperationId = `Me.Create${resourceName.slice(0, -1)}`;
     } else {
       createOperationId = `${resourceName}.Create`;
     }
 
     return tryGetOperation(createOperationId);
-  }, [meEndpoint, resource, resourceName, tryGetOperation]);
+  }, [isMeEndpoint, resourceName, tryGetOperation]);
 
   const deleteOperation = useMemo(() => {
     let deleteOperationId;
-    if (meEndpoint) {
-      deleteOperationId = `Me.Delete${resource.slice(0, -1)}`;
+    if (isMeEndpoint) {
+      deleteOperationId = `Me.Delete${resourceName.slice(0, -1)}`;
     } else {
       deleteOperationId = `${resourceName}.Delete`;
     }
 
     return tryGetOperation(deleteOperationId);
-  }, [meEndpoint, resource, resourceName, tryGetOperation]);
+  }, [isMeEndpoint, resourceName, tryGetOperation]);
 
   const assignmentListOperation = useMemo(() => {
     const assignmentListOperationId = `${resourceName}.List${

--- a/src/hooks/useOperations.ts
+++ b/src/hooks/useOperations.ts
@@ -1,49 +1,87 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import useApiSpec from './useApiSpec';
 import Case from 'case';
+import { IOrderCloudOperationObject } from '../models';
 
-const useOperations = (resource: string, operationInclusion?: string) => {
+const defaultReturn = { path: "", verb: "", operationId: ""} as IOrderCloudOperationObject
+
+const useOperations = (resource: string, operationInclusion?: string, meEndpoint?: boolean) => {
   const { operationsById } = useApiSpec()
+  const resourceName = useMemo(()=> resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1)),[resource])
+
+  const tryGetOperation = useCallback((operationId: string)=> {
+    return operationsById[operationId] || defaultReturn
+  },[operationsById])
   
   const listOperation = useMemo(() => {
-    const listOperationId = `${resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1))}.List`
-    return operationsById[listOperationId]
-  }, [operationsById, resource])
+    let listOperationId
+    if(meEndpoint){
+      listOperationId = `Me.List${resourceName}`
+    } else {
+      listOperationId = `${resourceName}.List`
+    }
+
+    return tryGetOperation(listOperationId)
+  }, [meEndpoint, resourceName, tryGetOperation])
 
   const getOperation = useMemo(() => {
-    const getOperationId = `${resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1))}.Get`
-    return operationsById[getOperationId]
-  }, [operationsById, resource])
+    let getOperationId
+    if(meEndpoint){
+      getOperationId = `Me.Get${resource.slice(0, -1)}`
+    } else {
+      getOperationId = `${resourceName}.Get`
+    }
+
+    return tryGetOperation(getOperationId)
+  }, [meEndpoint, resource, resourceName, tryGetOperation])
 
   const saveOperation = useMemo(() => {
-    const listOperationId = `${resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1))}.Save`
-   return operationsById[listOperationId]
-  }, [operationsById, resource])
+    let saveOperationId
+    if(meEndpoint){
+      saveOperationId = `Me.Save${resource.slice(0, -1)}`
+    } else {
+      saveOperationId = `${resourceName}.Save`
+    }
+
+    return tryGetOperation(saveOperationId)
+  }, [meEndpoint, resource, resourceName, tryGetOperation])
 
   const createOperation = useMemo(() => {
-    const listOperationId = `${resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1))}.Create`
-   return operationsById[listOperationId]
-  }, [operationsById, resource])
+    let createOperationId
+    if(meEndpoint){
+      createOperationId = `Me.Create${resource.slice(0, -1)}`
+    } else {
+      createOperationId = `${resourceName}.Create`
+    }
+    
+    return tryGetOperation(createOperationId)
+  }, [meEndpoint, resource, resourceName, tryGetOperation])
 
   const deleteOperation = useMemo(() => {
-    const listOperationId = `${resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1))}.Delete`
-   return operationsById[listOperationId]
-  }, [operationsById, resource])
+    let deleteOperationId
+    if(meEndpoint){
+      deleteOperationId = `Me.Delete${resource.slice(0, -1)}`
+    } else {
+      deleteOperationId = `${resourceName}.Delete`
+    }
+
+    return tryGetOperation(deleteOperationId)
+  }, [meEndpoint, resource, resourceName, tryGetOperation])
 
   const assignmentListOperation = useMemo(() => {
-    const assignmentListOperationId = `${resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1))}.List${operationInclusion ?? "" }Assignments`
-   return operationsById[assignmentListOperationId]
-  }, [operationInclusion, operationsById, resource])
+    const assignmentListOperationId = `${resourceName}.List${operationInclusion ?? "" }Assignments`
+    return tryGetOperation(assignmentListOperationId)
+  }, [operationInclusion, resourceName, tryGetOperation])
 
   const assignmentSaveOperation = useMemo(() => {
-    const assignmentSaveOperationId = `${resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1))}.Save${operationInclusion ?? "" }Assignment`
-   return operationsById[assignmentSaveOperationId]
-  }, [operationInclusion, operationsById, resource])
+    const assignmentSaveOperationId = `${resourceName}.Save${operationInclusion ?? "" }Assignment`
+    return tryGetOperation(assignmentSaveOperationId)
+  }, [operationInclusion, resourceName, tryGetOperation])
 
   const assignmentDeleteOperation = useMemo(() => {
-    const assignmentDeleteOperationId = `${resource.charAt(0).toUpperCase() + Case.camel(resource.slice(1))}.Delete${operationInclusion ?? "" }Assignment`
-   return operationsById[assignmentDeleteOperationId]
-  }, [operationInclusion, operationsById, resource])
+    const assignmentDeleteOperationId = `${resourceName}.Delete${operationInclusion ?? "" }Assignment`
+    return tryGetOperation(assignmentDeleteOperationId)
+  }, [operationInclusion, resourceName, tryGetOperation])
 
   const result = useMemo(() => {    
     return {

--- a/src/hooks/useShopper.ts
+++ b/src/hooks/useShopper.ts
@@ -13,8 +13,8 @@ import useAuthMutation from "./useAuthMutation";
 import { queryClient } from "..";
 
 const useShopper = () => {
-  const refetchWorksheet = useCallback(() => {
-    queryClient.refetchQueries({
+  const invalidateWorksheet = useCallback(() => {
+    queryClient.invalidateQueries({
       queryKey: ["worksheet"],
     });
   }, []);
@@ -28,7 +28,7 @@ const useShopper = () => {
     mutationKey: ["addCartLineItem"],
     mutationFn: async (lineItem: LineItem) =>
       await Cart.CreateLineItem(lineItem),
-    onSuccess: () => refetchWorksheet(),
+    onSuccess: () => invalidateWorksheet(),
   });
 
   const { mutateAsync: patchCartLineItem } = useAuthMutation({
@@ -40,26 +40,32 @@ const useShopper = () => {
       ID: string;
       lineItem: PartialDeep<LineItem>;
     }) => await Cart.PatchLineItem(ID, lineItem),
-    onSuccess: () => refetchWorksheet(),
+    onSuccess: () => invalidateWorksheet(),
+  });
+
+  const { mutateAsync: deleteCartLineItem } = useAuthMutation({
+    mutationKey: ["deleteCartLineItem"],
+    mutationFn: async (ID: string) => await Cart.DeleteLineItem(ID),
+    onSuccess: () => invalidateWorksheet(),
   });
 
   const { mutateAsync: addCartPromo } = useAuthMutation({
     mutationKey: ["addCartPromo"],
     mutationFn: async (promoCode: string) => await Cart.AddPromotion(promoCode),
-    onSuccess: () => refetchWorksheet(),
+    onSuccess: () => invalidateWorksheet(),
   });
 
   const { mutateAsync: removeCartPromo } = useAuthMutation({
     mutationKey: ["removeCartPromo"],
     mutationFn: async (promoCode: string) =>
       await Cart.DeletePromotion(promoCode),
-    onSuccess: () => refetchWorksheet(),
+    onSuccess: () => invalidateWorksheet(),
   });
 
   const { mutateAsync: applyPromotions } = useAuthMutation({
     mutationKey: ["addCartPromo"],
     mutationFn: async () => await Cart.ApplyPromotions(),
-    onSuccess: () => refetchWorksheet(),
+    onSuccess: () => invalidateWorksheet(),
   });
 
   const { mutateAsync: submitCart } = useAuthMutation({
@@ -68,13 +74,13 @@ const useShopper = () => {
       await Cart.Submit()
       return
     },
-    onSuccess: () => refetchWorksheet(),
+    onSuccess: () => invalidateWorksheet(),
   });
 
   const { mutateAsync: deleteCart } = useAuthMutation({
     mutationKey: ["deleteCart"],
     mutationFn: async () => await Cart.Delete(),
-    onSuccess: () => refetchWorksheet(),
+    onSuccess: () => invalidateWorksheet(),
   });
 
   return useMemo(() => {
@@ -82,6 +88,7 @@ const useShopper = () => {
       orderWorksheet,
       addCartLineItem,
       patchCartLineItem,
+      deleteCartLineItem,
       addCartPromo,
       submitCart,
       deleteCart,
@@ -92,6 +99,7 @@ const useShopper = () => {
     orderWorksheet,
     addCartLineItem,
     patchCartLineItem,
+    deleteCartLineItem,
     addCartPromo,
     submitCart,
     deleteCart,

--- a/src/hooks/useShopper.ts
+++ b/src/hooks/useShopper.ts
@@ -64,7 +64,10 @@ const useShopper = () => {
 
   const { mutateAsync: submitCart } = useAuthMutation({
     mutationKey: ["submitCart"],
-    mutationFn: async () => await Cart.Submit(),
+    mutationFn: async () => {
+      await Cart.Submit()
+      return
+    },
     onSuccess: () => refetchWorksheet(),
   });
 

--- a/src/hooks/useShopper.ts
+++ b/src/hooks/useShopper.ts
@@ -19,7 +19,11 @@ const useShopper = () => {
     });
   }, []);
 
-  const { data: orderWorksheet } = useAuthQuery({
+  const {
+    data: orderWorksheet,
+    isLoading,
+    isPending,
+  } = useAuthQuery({
     queryKey: ["worksheet"],
     queryFn: async () => await Cart.GetOrderWorksheet(),
   }) as UseQueryResult<RequiredDeep<OrderWorksheet>, OrderCloudError>;
@@ -71,8 +75,8 @@ const useShopper = () => {
   const { mutateAsync: submitCart } = useAuthMutation({
     mutationKey: ["submitCart"],
     mutationFn: async () => {
-      await Cart.Submit()
-      return
+      await Cart.Submit();
+      return;
     },
     onSuccess: () => invalidateWorksheet(),
   });
@@ -86,6 +90,7 @@ const useShopper = () => {
   return useMemo(() => {
     return {
       orderWorksheet,
+      worksheetLoading: isPending || isLoading,
       addCartLineItem,
       patchCartLineItem,
       deleteCartLineItem,
@@ -97,6 +102,8 @@ const useShopper = () => {
     };
   }, [
     orderWorksheet,
+    isPending,
+    isLoading,
     addCartLineItem,
     patchCartLineItem,
     deleteCartLineItem,

--- a/src/hooks/useShopper.ts
+++ b/src/hooks/useShopper.ts
@@ -1,0 +1,100 @@
+import { useCallback, useMemo } from "react";
+import useAuthQuery from "./useAuthQuery";
+import {
+  Cart,
+  LineItem,
+  OrderCloudError,
+  OrderWorksheet,
+  PartialDeep,
+  RequiredDeep,
+} from "ordercloud-javascript-sdk";
+import { UseQueryResult } from "@tanstack/react-query";
+import useAuthMutation from "./useAuthMutation";
+import { queryClient } from "..";
+
+const useShopper = () => {
+  const refetchWorksheet = useCallback(() => {
+    queryClient.refetchQueries({
+      queryKey: ["worksheet"],
+    });
+  }, []);
+
+  const { data: orderWorksheet } = useAuthQuery({
+    queryKey: ["worksheet"],
+    queryFn: async () => await Cart.GetOrderWorksheet(),
+  }) as UseQueryResult<RequiredDeep<OrderWorksheet>, OrderCloudError>;
+
+  const { mutateAsync: addCartLineItem } = useAuthMutation({
+    mutationKey: ["addCartLineItem"],
+    mutationFn: async (lineItem: LineItem) =>
+      await Cart.CreateLineItem(lineItem),
+    onSuccess: () => refetchWorksheet(),
+  });
+
+  const { mutateAsync: patchCartLineItem } = useAuthMutation({
+    mutationKey: ["patchCartLineItem"],
+    mutationFn: async ({
+      ID,
+      lineItem,
+    }: {
+      ID: string;
+      lineItem: PartialDeep<LineItem>;
+    }) => await Cart.PatchLineItem(ID, lineItem),
+    onSuccess: () => refetchWorksheet(),
+  });
+
+  const { mutateAsync: addCartPromo } = useAuthMutation({
+    mutationKey: ["addCartPromo"],
+    mutationFn: async (promoCode: string) => await Cart.AddPromotion(promoCode),
+    onSuccess: () => refetchWorksheet(),
+  });
+
+  const { mutateAsync: removeCartPromo } = useAuthMutation({
+    mutationKey: ["removeCartPromo"],
+    mutationFn: async (promoCode: string) =>
+      await Cart.DeletePromotion(promoCode),
+    onSuccess: () => refetchWorksheet(),
+  });
+
+  const { mutateAsync: applyPromotions } = useAuthMutation({
+    mutationKey: ["addCartPromo"],
+    mutationFn: async () => await Cart.ApplyPromotions(),
+    onSuccess: () => refetchWorksheet(),
+  });
+
+  const { mutateAsync: submitCart } = useAuthMutation({
+    mutationKey: ["submitCart"],
+    mutationFn: async () => await Cart.Submit(),
+    onSuccess: () => refetchWorksheet(),
+  });
+
+  const { mutateAsync: deleteCart } = useAuthMutation({
+    mutationKey: ["deleteCart"],
+    mutationFn: async () => await Cart.Delete(),
+    onSuccess: () => refetchWorksheet(),
+  });
+
+  return useMemo(() => {
+    return {
+      orderWorksheet,
+      addCartLineItem,
+      patchCartLineItem,
+      addCartPromo,
+      submitCart,
+      deleteCart,
+      removeCartPromo,
+      applyPromotions,
+    };
+  }, [
+    orderWorksheet,
+    addCartLineItem,
+    patchCartLineItem,
+    addCartPromo,
+    submitCart,
+    deleteCart,
+    removeCartPromo,
+    applyPromotions,
+  ]);
+};
+
+export default useShopper;

--- a/src/models/IOrderCloudContext.ts
+++ b/src/models/IOrderCloudContext.ts
@@ -30,5 +30,6 @@ export interface IOrderCloudContext {
   allowAnonymous: boolean;
   defaultErrorHandler?: (error:OrderCloudError, context:IOrderCloudErrorContext) => void;
   token?: string;
-  xpSchemas?: OpenAPIV3.SchemaObject
+  xpSchemas?: OpenAPIV3.SchemaObject;
+  autoApplyPromotions?: boolean;
 }

--- a/src/models/IOrderCloudProvider.ts
+++ b/src/models/IOrderCloudProvider.ts
@@ -8,7 +8,8 @@ export interface IOrderCloudProvider {
     scope: ApiRole[];
     customScope: string[];
     allowAnonymous: boolean;
-    xpSchemas?: OpenAPIV3.SchemaObject
+    xpSchemas?: OpenAPIV3.SchemaObject,
+    autoApplyPromotions: boolean,
     defaultErrorHandler?: (error:OrderCloudError, context:Omit<IOrderCloudContext, "defaultErrorHandler">) => void
   }
   

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -17,9 +17,9 @@ import { OrderCloudContext } from "./context";
 import { IOrderCloudProvider } from "./models/IOrderCloudProvider";
 import { asyncStoragePersister, queryClient } from "./query";
 import { isAnonToken } from "./utils";
-import axios from 'axios'
+import axios from "axios";
 
-let interceptorSetup = false
+let interceptorSetup = false;
 const OrderCloudProvider: FC<PropsWithChildren<IOrderCloudProvider>> = ({
   children,
   baseApiUrl,
@@ -102,13 +102,6 @@ const OrderCloudProvider: FC<PropsWithChildren<IOrderCloudProvider>> = ({
   }, [allowAnonymous, clientId, scope, customScope, handleLogout]);
 
   useEffect(() => {
-    if (!isAuthenticated) {
-      verifyToken();
-    }
-  }, [isAuthenticated, verifyToken]);
-
-  useEffect(() => {
-    
     Configuration.Set({
       cookieOptions: {
         prefix: clientId,
@@ -118,21 +111,27 @@ const OrderCloudProvider: FC<PropsWithChildren<IOrderCloudProvider>> = ({
     });
 
     if (!interceptorSetup) {
-      axios.interceptors.request.use(async (config) => {
-        await verifyToken();
-        const verifiedToken = Tokens.GetAccessToken();
-        config.headers.Authorization = `Bearer ${verifiedToken}`;
-        // Do something before request is sent
-        return config;
-      }, function (error) {
-        // Do something with request error
-        return Promise.reject(error);
-      });
+      axios.interceptors.request.use(
+        async (config) => {
+          await verifyToken();
+          const verifiedToken = Tokens.GetAccessToken();
+          config.headers.Authorization = `Bearer ${verifiedToken}`;
+          // Do something before request is sent
+          return config;
+        },
+        function (error) {
+          // Do something with request error
+          return Promise.reject(error);
+        }
+      );
     } else {
       interceptorSetup = true;
     }
-    
-  }, [baseApiUrl, clientId, verifyToken]);
+
+    if (!isAuthenticated) {
+      verifyToken();
+    }
+  }, [baseApiUrl, clientId, isAuthenticated, verifyToken]);
 
   const ordercloudContext = useMemo(() => {
     return {

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -28,6 +28,7 @@ const OrderCloudProvider: FC<PropsWithChildren<IOrderCloudProvider>> = ({
   customScope,
   allowAnonymous,
   xpSchemas,
+  autoApplyPromotions,
   defaultErrorHandler,
 }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -144,6 +145,7 @@ const OrderCloudProvider: FC<PropsWithChildren<IOrderCloudProvider>> = ({
       isLoggedIn,
       token,
       xpSchemas,
+      autoApplyPromotions,
       logout: handleLogout,
       login: handleLogin,
       defaultErrorHandler,
@@ -158,6 +160,7 @@ const OrderCloudProvider: FC<PropsWithChildren<IOrderCloudProvider>> = ({
     isLoggedIn,
     token,
     xpSchemas,
+    autoApplyPromotions,
     handleLogout,
     handleLogin,
     defaultErrorHandler,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,8 @@ export const isRouteParam = (operation: any, paramName: string) => {
 }
 
 export const getRoutingUrl = (operation: any, params: any)=> {
-  let url = operation.path
+  let url = operation?.path
+  if(!url) return ""
   const paramsTest = params
   if (url.indexOf('{') > -1) {
     Object.entries(paramsTest)


### PR DESCRIPTION
- Updates the useOcResource hooks to incorporate Me endpoints.  Specifying `Me.{resourceName}` as the resource argument in the hook will use the associated 'Me' endpoint in OrderCloud
  - A new useOcResource hook was also added, useOcResourceListWithFacets that returns the type `UseQueryResult<RequiredDeep<ListPageWithFacets<TData>>, OrderCloudError>`
- Adds a new `useShopper` hook with basic cart actions that returns an order worksheet. Actions include:
  - addCartLineItem
  - patchCartLineItem
  - deleteCartLineItem
  - addCartPromo
  - submitCart
  - deleteCart
  - removeCartPromo
  - applyPromotions
  - eligiblePromotions