### PR TITLE
Chain values of the same facet with '|'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rwatt451/ordercloud-react",
   "private": false,
-  "version": "0.0.37",
+  "version": "0.0.38",
   "type": "module",
   "files": [
     "package.json",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,12 +86,10 @@ export const makeQueryString = (params: ServiceListOptions | undefined) => {
       } else {
         if (typeof val === 'object' && (key === 'searchOn' || key === 'sortBy')) {
           return `${key}=${val.map(encodeURIComponent).join(',')}`
-        } else if (typeof val === 'object') {
-          return val
-            .map((v: any) => {
-              return `${key}=${encodeURIComponent(v)}`
-            })
-            .join('&')
+        } else if (typeof val === "object") {
+          return `${key}=${val
+            .map((v: string) => encodeURIComponent(v))
+            .join("|")}`
         } else {
           return `${key}=${encodeURIComponent(val)}`
         }


### PR DESCRIPTION
Fixes a bug in accelerator where multiple values of the same facet (e.g. brand = 'striva' OR 'centercycle') were being joined with AND