### PR TITLE
Support for currencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ The OrderCloud resource name used for generating column information.
 #### **sortOrder**: `string[]`
 An **optional** list that will be used to sort table header order if provided.
 
-#### **cellCallback**: `(cellValue: unknown, properties: unknown) => JSX.Element`
+#### **cellCallback**: `(info: CellContext<unknown, unknown>, properties: OpenAPIV3.SchemaObject, resourceId: string) => JSX.Element`
 An **optional** callback for defining custom elements for `@tanstack/react-table` table cells by data type.
 
 ## `useOcForm()` hook

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rwatt451/ordercloud-react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rwatt451/ordercloud-react",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",
         "@react-native-async-storage/async-storage": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rwatt451/ordercloud-react",
   "private": false,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "files": [
     "package.json",

--- a/src/constants/currencies.ts
+++ b/src/constants/currencies.ts
@@ -1,0 +1,172 @@
+import {
+  LineItem,
+  Order,
+  OrderReturn,
+  Payment,
+  PriceSchedule,
+  ShipmentItem,
+} from "ordercloud-javascript-sdk";
+import { useOcResourceGet, useOrderCloudContext } from "../hooks";
+
+interface CurrencyValues {
+  languageType: string;
+  currencyType: string;
+}
+
+interface ICurrencyData {
+  currencyProperties: Array<string>;
+  dependencies?: Array<string>;
+  renderCurrencyInputs(
+    tableRow?: unknown,
+    params?: Array<string>
+  ): CurrencyValues;
+}
+
+const getCurrencyValues = (
+  language?: string | null,
+  currency?: string | null
+) => {
+  // if no value passed in, use default from the provider
+  const { currencyDefaults } = useOrderCloudContext();
+  return {
+    languageType: language || currencyDefaults.language,
+    currencyType: currency || currencyDefaults.currencyCode,
+  };
+};
+
+const OrderCurrency: ICurrencyData = {
+  currencyProperties: [
+    "Subtotal",
+    "ShippingCost",
+    "TaxCost",
+    "Gratuity",
+    "PromotionDiscount",
+    "Total",
+  ],
+  renderCurrencyInputs: (order: any) => {
+    const language = order?.FromUser?.Locale?.Language;
+    const currency = order?.Currency;
+    return getCurrencyValues(language, currency);
+  },
+};
+
+const LineItemCurrency: ICurrencyData = {
+  currencyProperties: [
+    "UnitPrice",
+    "PromotionDiscount",
+    "LineTotal",
+    "LineSubtotal",
+    "PriceMarkup",
+  ],
+  dependencies: ["direction"],
+  renderCurrencyInputs: (lineItem: LineItem, params: Array<string>) => {
+    var orderResult = useOcResourceGet<Order>("Orders", {
+      direction: params[0]!,
+      orderID: lineItem.IncomingOrderID!,
+    });
+    const language = orderResult?.data?.FromUser?.Locale?.Language;
+    const currency = orderResult?.data?.Currency;
+    return getCurrencyValues(language, currency);
+  },
+};
+
+const PriceScheduleCurrency: ICurrencyData = {
+  currencyProperties: [
+    "Price",
+    "SalePrice",
+    "SubscriptionPrice",
+    "BundlePrice",
+  ],
+  renderCurrencyInputs: (ps: PriceSchedule) => {
+    const currency = ps?.Currency;
+    return getCurrencyValues(null, currency);
+  },
+};
+
+const SpecCurrency: ICurrencyData = {
+  currencyProperties: ["PriceMarkup"],
+  renderCurrencyInputs: () => getCurrencyValues(),
+};
+
+const SpendingAccountCurrency: ICurrencyData = {
+  currencyProperties: ["Balance"],
+  renderCurrencyInputs: () => getCurrencyValues(),
+};
+
+const ShipmentCurrency: ICurrencyData = {
+  currencyProperties: ["Cost"],
+  renderCurrencyInputs: () => getCurrencyValues(),
+};
+
+const ShipmentItemCurrency: ICurrencyData = {
+  currencyProperties: ["UnitPrice"],
+  // note: if multiple order IDs exist on a list of shipment items, this will make a call for each
+  renderCurrencyInputs: (shipmentItem: ShipmentItem) => {
+    var orderResult = useOcResourceGet<Order>("Orders", {
+      direction: "Incoming",
+      orderID: shipmentItem.OrderID!,
+    });
+    const language = orderResult?.data?.FromUser?.Locale?.Language;
+    const currency = orderResult?.data?.Currency;
+    return getCurrencyValues(language, currency);
+  },
+};
+
+const OrderReturnCurrency: ICurrencyData = {
+  currencyProperties: ["RefundAmount"],
+  renderCurrencyInputs: (orderReturn: OrderReturn) => {
+    var orderResult = useOcResourceGet<Order>("Orders", {
+      direction: "Incoming",
+      orderID: orderReturn.OrderID,
+    });
+    const language = orderResult?.data?.FromUser?.Locale?.Language;
+    const currency = orderResult?.data?.Currency;
+    return getCurrencyValues(language, currency);
+  },
+};
+
+const PaymentCurrency: ICurrencyData = {
+  currencyProperties: ["Amount"],
+  dependencies: ["direction", "orderID"], // order ID only available in parameters
+  renderCurrencyInputs: (_payment: Payment, params: Array<string>) => {
+    var orderResult = useOcResourceGet<Order>("Orders", {
+      direction: params[0]!,
+      orderID: params[1]!,
+    });
+    const language = orderResult?.data?.FromUser?.Locale?.Language;
+    const currency = orderResult?.data?.Currency;
+    return getCurrencyValues(language, currency);
+  },
+};
+
+const PromotionsCurrency: ICurrencyData = {
+  currencyProperties: ["Amount"],
+  dependencies: ["direction", "orderID"], // order ID only available in parameters
+  renderCurrencyInputs: (_promotion: Payment, params: Array<string>) => {
+    var orderResult = useOcResourceGet<Order>("Orders", {
+      direction: params[0]!,
+      orderID: params[1]!,
+    });
+    const language = orderResult?.data?.FromUser?.Locale?.Language;
+    const currency = orderResult?.data?.Currency;
+    return getCurrencyValues(language, currency);
+  },
+};
+
+export const currencyFormats: {
+  [resourceID: string]: ICurrencyData;
+} = {
+  Orders: OrderCurrency,
+  LineItems: LineItemCurrency,
+  SpecOptions: SpecCurrency,
+  Shipments: ShipmentCurrency,
+  OrderShipment: ShipmentCurrency,
+  ShipmentItems: ShipmentItemCurrency,
+  Payments: PaymentCurrency,
+  OrderReturns: OrderReturnCurrency,
+  SpendingAccounts: SpendingAccountCurrency,
+  PriceSchedules: PriceScheduleCurrency,
+  SubscriptionItems: LineItemCurrency,
+  Promotions: PromotionsCurrency,
+  OrderPromotions: PromotionsCurrency,
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,5 @@
+import { currencyFormats } from "./currencies";
+
+export {
+  currencyFormats
+};

--- a/src/context.ts
+++ b/src/context.ts
@@ -23,7 +23,8 @@ const INITIAL_ORDERCLOUD_CONTEXT: IOrderCloudContext = {
   token: undefined,
   autoApplyPromotions: false,
   xpSchemas: {} as OpenAPIV3.SchemaObject,
-  authLoading: true
+  authLoading: true,
+  currencyDefaults: {} as { currencyCode: string, language: string }
 };
 
 export const OrderCloudContext = createContext<IOrderCloudContext>(

--- a/src/hooks/useColumns.ts
+++ b/src/hooks/useColumns.ts
@@ -2,14 +2,14 @@ import { useCallback, useMemo } from 'react'
 import { OpenAPIV3 } from 'openapi-types';
 import { useOrderCloudContext } from '.';
 import { sortBy, get } from 'lodash';
-import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { CellContext, ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { RequiredDeep } from 'ordercloud-javascript-sdk';
 import { getRequiredParamsInPath } from '../utils';
 import useOperations from './useOperations';
 
 const columnHelper = createColumnHelper<RequiredDeep<unknown>>();
 
-const useColumns = (resourceId: string, sortOrder?: string[], cellCallback?: (cellValue: unknown, properties: OpenAPIV3.SchemaObject) => JSX.Element) => {
+const useColumns = (resourceId: string, sortOrder?: string[], cellCallback?: (info: CellContext<unknown, unknown>, properties: OpenAPIV3.SchemaObject, resourceId: string) => JSX.Element) => {
   const { xpSchemas } = useOrderCloudContext()
   const { listOperation: operation, deleteOperation, assignmentListOperation} = useOperations(resourceId)
 
@@ -92,9 +92,8 @@ const useColumns = (resourceId: string, sortOrder?: string[], cellCallback?: (ce
             header,
             enableResizing: true,
             enableSorting: sortable?.includes(accessorString),
-            cell: (info) => {
-              const cellValue = info.getValue();
-              return cellCallback(cellValue, value)
+            cell: (info: CellContext<unknown, unknown>) => {
+              return cellCallback(info, value, resourceId) 
             }
           }) as ColumnDef<unknown, unknown>
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {queryClient} from "./query";
 import {parseToken} from "./utils";
 export * from "./hooks";
 export * from "./models";
+export * from './constants'
 
 export {
     parseToken,

--- a/src/models/IOrderCloudContext.ts
+++ b/src/models/IOrderCloudContext.ts
@@ -47,4 +47,5 @@ export interface IOrderCloudContext {
   token?: string;
   xpSchemas?: OpenAPIV3.SchemaObject;
   autoApplyPromotions?: boolean;
+  currencyDefaults: { currencyCode: string, language: string }
 }

--- a/src/models/IOrderCloudProvider.ts
+++ b/src/models/IOrderCloudProvider.ts
@@ -11,6 +11,7 @@ export interface IOrderCloudProvider {
     xpSchemas?: OpenAPIV3.SchemaObject;
     autoApplyPromotions?: boolean,
     configurationOverrides?: Omit<SdkConfiguration, 'baseApiUrl' | 'clientID'>
+    currencyDefaults?: { currencyCode: string, language: string }
     defaultErrorHandler?: (error:OrderCloudError, context:Omit<IOrderCloudContext, "defaultErrorHandler">) => void
   }
   

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -30,6 +30,7 @@ const OrderCloudProvider: FC<PropsWithChildren<IOrderCloudProvider>> = ({
   xpSchemas,
   autoApplyPromotions,
   configurationOverrides,
+  currencyDefaults = { currencyCode: "USD", language: "en-US" },
   defaultErrorHandler,
 }) => {
   const ocConfig = useMemo(() => {
@@ -205,6 +206,7 @@ const OrderCloudProvider: FC<PropsWithChildren<IOrderCloudProvider>> = ({
       xpSchemas,
       autoApplyPromotions,
       authLoading,
+      currencyDefaults,
       logout: handleLogout,
       login: handleLogin,
       setToken: handleProvidedToken,
@@ -223,6 +225,7 @@ const OrderCloudProvider: FC<PropsWithChildren<IOrderCloudProvider>> = ({
     xpSchemas,
     autoApplyPromotions,
     authLoading,
+    currencyDefaults,
     handleLogout,
     handleLogin,
     handleProvidedToken,


### PR DESCRIPTION
- Specify which properties per OC resource will be displayed monetary properties in a tanstack table cell
- Add ability to pass default currency and language options into ordercloud-react at the provider level.  If none is provided, it will default to currency: `USD` and language: `en-US`
- If currency or language is defined on the item itself (row), pass the row into the `renderCurrencyInputs` callback. I.e. `Order.Currency`
- If the currency or language is indirectly defined for an item, define any dependencies needed to make the associated OC call. For example, payments are indirectly tied to orders with currency and language information, but require order direction and order ID to make a GET /orders call